### PR TITLE
Provide "Is Reagent" option on container objects.

### DIFF
--- a/BIOBLOCKS/containerLib.js
+++ b/BIOBLOCKS/containerLib.js
@@ -111,6 +111,12 @@ Blockly.Blocks['container'] = {
 			.setAlign(Blockly.ALIGN_RIGHT)
 			.appendField("Destiny")
 			.appendField(new Blockly.FieldDropdown([["Store at Ambient", "Ambient"], ["Store at -80 deg.C", "Minus80"], ["Store at -20 deg.C", "minus20"], ["Store at 0 deg.C", "Zero"], ["Store at 4 deg.C", "Four"], ["Discard in Bio-Waste", "Bio-Waste"], ["Discard in Chemical-Waste", "Chemical-Waste"], ["Discard in Regular-Waste", "Regular-Waste"]]), "Destiny");
+	
+		this.appendDummyInput("Is_Reagent")
+			.setAlign(Blockly.ALIGN_RIGHT)
+			.appendField("Is Reagent")
+			.appendField(new Blockly.FieldDropdown([["True", "True"], ["False", "False"]]), "Is_Reagent");
+
 	},
 		
 /****************************************************************************************************************************************************************/		
@@ -167,6 +173,8 @@ Blockly.Blocks['container'] = {
 		
 		currentArray['containerName']=this.getFieldValue('containerName');//Saving the value of parameter containerName, in the same space of the LOCAL array. This example is the same for the remaining parameters
 		currentArray['Destiny']=this.getFieldValue('Destiny');
+		currentArray['Is_Reagent']=this.getFieldValue('Is_Reagent');
+
 		//currentArray['SEAL-COVER']=this.getFieldValue('SEAL-COVER');
 		
 		var volumeBlock = this.getInputTargetBlock('volume');

--- a/naturalLanguage_english_bioBlocks.js
+++ b/naturalLanguage_english_bioBlocks.js
@@ -359,10 +359,11 @@ Blockly.NaturalLanguage_english['experiment'] = function(block) {
 	var childrenArray = this.getDescendants(); /*Get all the children*/
 	for(var k=0;k<childrenArray.length;k++){ /*Loop to write all names of different containers*/
 		if (childrenArray.hasOwnProperty(k)){
-			if(childrenArray[k].getFieldValue("containerName")){
-				if (!comparationArray.hasOwnProperty(childrenArray[k].getFieldValue("containerName"))){
-					code = code + '* ' + childrenArray[k].getFieldValue("containerName") +' \n';
-					comparationArray[childrenArray[k].getFieldValue("containerName")]=k;
+			var container = childrenArray[k];
+			if(container.getFieldValue("containerName") && container.getFieldValue("Is_Reagent") == "True" ){
+				if (!comparationArray.hasOwnProperty(container.getFieldValue("containerName"))){
+					code = code + '* ' + container.getFieldValue("containerName") +' \n';
+					comparationArray[container.getFieldValue("containerName")] = k;
 				}
 			}
 		}


### PR DESCRIPTION
This determines whether they should be listed in the "Solutions/reagents" section of the natural language protocol. 

Without this, the list incorrectly includes any initially-empty container that is necessary to carry out a protocol on the list of reagents.